### PR TITLE
verify probe chan mapping (wip)

### DIFF
--- a/pipeline/run_shank.py
+++ b/pipeline/run_shank.py
@@ -52,6 +52,7 @@ def collect_files(data_folder: Path, probe_name: str) -> list[str]:
     Returns:
         list: File paths matching the probe name.
     """
+    # todo - sort the files thoughtfully so they get concatenated appropriately in time
     recording_files = glob.glob(f"{str(data_folder)}/{probe_name}*")
     print(f"Found {len(recording_files)} files for {probe_name}")
     return recording_files
@@ -112,7 +113,20 @@ def split_recording(
         recording_paths.append(recording_file)
 
     total_recording = si.concatenate_recordings(recordings)
-    total_recording.set_probe(global_probe_data)
+
+    # try to check out channel ordering again here - not 100% but leaving to catch 
+    tmp_dev_indices = np.asarray(global_probe_data.device_channel_indices, dtype=int)
+    tmp_expected_indices = np.arange(total_recording.get_num_channels(), dtype=int)
+    if not np.array_equal(tmp_dev_indices, tmp_expected_indices):
+        raise ValueError("Check probe ordering..." \
+            f"device channel indices from global probe data: {tmp_dev_indices.tolist()}" \
+            f"expected channel indices from recording: {tmp_expected_indices.tolist()}" \
+        )
+    
+    total_recording = total_recording.set_probe(global_probe_data)
+
+    # could also try to check shank ids from global probe data here
+    # and compare it to the num chans in shank probe obj?
 
     # 1. Highpass filter and phase shift before artifact removal to avoid
     #    filter ringing at zero-padded artifact edges
@@ -155,6 +169,7 @@ def split_recording(
         )
 
     rec = rec_split[shank_key]
+    #todo - perhaps add sanity check here too that num chans makes sense and local shank indexing makes sense
     rec = rec.set_probe(shank_probe)
 
     # 3. DREDge motion correction per shank (before CMR)

--- a/utils/probe_utils.py
+++ b/utils/probe_utils.py
@@ -4,6 +4,10 @@ Probe loading utilities for neuropixels data processing.
 
 This module provides common functions for loading and processing probe configurations
 from JSON files, including filtering by active channels and shank numbers.
+
+Note that the probe json gets loaded, but then its fields are reordered to all
+match the order of the channels in the recording .bin, so by channel, not physical contact layout.
+
 """
 
 from __future__ import annotations
@@ -11,7 +15,18 @@ from __future__ import annotations
 import json
 import numpy as np
 import probeinterface as pi
+from pathlib import Path
+import copy
 
+PROBE_ARRAY_KEYS = [
+    'contact_positions',
+    'contact_plane_axes',
+    'contact_shapes',
+    'contact_shape_params',
+    'device_channel_indices',
+    'contact_ids',
+    'shank_ids'
+]
 
 def find_active_channels(probe_dict: dict) -> np.ndarray:
     """Find active channels in probe configuration."""
@@ -25,6 +40,37 @@ def find_shank_channels(probe_dict: dict, shank_num: int | str) -> np.ndarray:
     shank_num_str = str(shank_num)
     return np.array([str(s) == shank_num_str for s in shank_ind])
 
+def sort_probe_arrays_by_device_chan(probe: dict) -> None:
+    """
+    Sort active probe rows so row i corresponds to channel i.
+    This is because the probe json info is in physical contact and shank order.
+    However, the raw .bin is in channel order, so use the device_channel_indices
+    to map the json info to match up to the raw data.
+
+    This assumes also that inactive contacts have been removed already.
+    """
+    # check some basics
+    dev_ind = np.asarray(probe["device_channel_indices"], dtype=int)
+    if np.any(dev_ind == -1):
+        raise ValueError(
+            "inactive contacts remain in probe json arrays, filter out device_channel_indices == -1 before this."
+        )
+    
+    if len(np.unique(dev_ind)) != len(dev_ind):
+        raise ValueError(
+            "Duplicates found in device_channel_indices, so can't sort probe arrays by device channel index."
+        )
+    
+    expected = np.arange(len(dev_ind))
+    if not np.array_equal(np.sort(dev_ind), expected):
+        raise ValueError(
+            f"device_channel_indices should contain all ints from 0 to {len(dev_ind)-1} with no duplicates, but got {np.sort(dev_ind)}"
+        )       
+
+    order = np.argsort(dev_ind) # sort active device chan indices ascending, to match raw .bin data
+
+    for key in PROBE_ARRAY_KEYS:
+        probe[key] = np.asarray(probe[key])[order] # reorder json fields
 
 def load_probe(
     probe_file: str | Path,
@@ -32,8 +78,16 @@ def load_probe(
     n_channels_shank: int | None = None,
 ) -> tuple[pi.Probe, int | None]:
     """
-    Load probe configuration from JSON file.
+    Load probe configuration/ProbeInterface probe object from JSON file.
     
+    Note that the probe json gets loaded, but then its fields are reordered
+    to all match the order of the channels in the recording .bin, so by channel,
+    not physical contact layout. The returned probe object is ordered by raw channel.
+    So returned probe data corresponds to raw .bin chan i.
+
+    If things are shank sliced, then probe info should be in same order as in shank sliced rec data
+    with device_channel_indices reset to local indices 0 to n-1.
+
     Args:
         probe_file: Path to probe configuration JSON file
         shank_num: Optional shank number to filter channels
@@ -46,26 +100,36 @@ def load_probe(
     with open(probe_file, 'r') as f:
         probe_dict = json.load(f)
     
+    probe_dict = copy.deepcopy(probe_dict) # to avoid modifying original dict in place, since we will filter/reorder fields
+
     active_channels_mask = find_active_channels(probe_dict)
     probe = probe_dict['probes'][0]  # get the first probe
 
     # First filter by active channels
-    for key in ['contact_positions', 'contact_plane_axes', 'contact_shapes', 
-                'contact_shape_params', 'device_channel_indices', 'contact_ids', 'shank_ids']:
+    for key in PROBE_ARRAY_KEYS:
         probe[key] = np.array(probe[key])[active_channels_mask]
+
+    # Get the mapping to match here, converting json physical order to chan order
+    sort_probe_arrays_by_device_chan(probe)
 
     # Then filter by shank if specified
     n_channels = None
     if shank_num is not None:
         shank_channels_mask = find_shank_channels(probe, shank_num)
-        for key in ['contact_positions', 'contact_plane_axes', 'contact_shapes', 
-                    'contact_shape_params', 'device_channel_indices', 'contact_ids', 'shank_ids']:
+        for key in PROBE_ARRAY_KEYS:
             probe[key] = probe[key][shank_channels_mask]
+        
         # Count actual channels from JSON after filtering
         n_channels = len(probe['device_channel_indices'])
-        # Use provided n_channels_shank if given, otherwise use count from JSON
-        channels_count = n_channels_shank if n_channels_shank is not None else n_channels
-        probe['device_channel_indices'] = np.arange(0, channels_count)
+
+        # If n chan shank was given make sure it makes sense
+        if n_channels_shank is not None and n_channels_shank != n_channels:
+            raise ValueError(
+                f"your n_channels_shank {n_channels_shank} does not match count from JSON {n_channels} after filtering for shank {shank_num}."
+            )
+
+        # Once split rec into a shank, shank rec is locally indexed 0 to n-1, so make sure shank probe uses these indices too
+        probe['device_channel_indices'] = np.arange(n_channels)
 
     probe = pi.Probe.from_dict(probe)
     return probe, n_channels

--- a/utils/probe_utils.py
+++ b/utils/probe_utils.py
@@ -71,6 +71,8 @@ def sort_probe_arrays_by_device_chan(probe: dict) -> None:
 
     for key in PROBE_ARRAY_KEYS:
         probe[key] = np.asarray(probe[key])[order] # reorder json fields
+        # or consider making new probe obj that has the reordered metadata rather than in place modification
+        # then have fxn return that new probe dict and convert to pi obj after?
 
 def load_probe(
     probe_file: str | Path,
@@ -110,7 +112,7 @@ def load_probe(
         probe[key] = np.array(probe[key])[active_channels_mask]
 
     # Get the mapping to match here, converting json physical order to chan order
-    sort_probe_arrays_by_device_chan(probe)
+    sort_probe_arrays_by_device_chan(probe) 
 
     # Then filter by shank if specified
     n_channels = None


### PR DESCRIPTION
See more info in issue #17 , here aim to reorder active json contact info by channel to match raw bin data order.

I also made some comments throughout as todo notes where I didn't have time to fully implement more sanity checks. For ex, when probe data gets split into shanks would be a great place for some extra checks on n chans, channel ids, and their indices. Same for the sample shifting step.

The code still needs to be tested and reviewed, i haven't plotted or run or tested anything (!!) But did want to get us started so we can move quickly on this as needed given we're making npx12 decisions. 

Happy to talk through and make sure all on the same page.